### PR TITLE
Clipboard file copy

### DIFF
--- a/aardwolf/commons/iosettings.py
+++ b/aardwolf/commons/iosettings.py
@@ -1,4 +1,5 @@
 from aardwolf.extensions.RDPECLIP.channel import RDPECLIPChannel
+from aardwolf.extensions.RDPECLIP.clipboard import Clipboard
 from aardwolf.protocol.x224.constants import SUPP_PROTOCOLS, NEG_FLAGS
 from aardwolf.commons.queuedata.constants import VIDEO_FORMAT
 from aardwolf.protocol.T125.extendedinfopacket import PERF
@@ -58,6 +59,7 @@ class RDPIOSettings:
 		# set it to true to have a file created, or to a string with a file path
 		# 
 		self.clipboard_store_data = None
+		self.clipboard = Clipboard()
 
 		# determines how often the client polls for desktop changes
 		self.vnc_fps = 10

--- a/aardwolf/commons/queuedata/clipboard.py
+++ b/aardwolf/commons/queuedata/clipboard.py
@@ -1,4 +1,7 @@
+from typing import Any, Protocol
+
 from aardwolf.extensions.RDPECLIP.protocol.formatlist import CLIPBRD_FORMAT
+from aardwolf.extensions.RDPECLIP.protocol.formatdataresponse import CLIPRDR_FILELIST
 from aardwolf.commons.queuedata import RDPDATATYPE
 
 
@@ -26,16 +29,25 @@ class RDP_CLIPBOARD_NEW_DATA_AVAILABLE:
 	"""
 	def __init__(self):
 		self.type = RDPDATATYPE.CLIPBOARD_NEW_DATA_AVAILABLE
-	
-class RDP_CLIPBOARD_DATA_TXT:
+
+class RDP_CLIPBOARD_DATA(Protocol):
+	data:Any
+	datatype:CLIPBRD_FORMAT
+
+class RDP_CLIPBOARD_DATA_FILELIST(RDP_CLIPBOARD_DATA):
+	def __init__(self, data:CLIPRDR_FILELIST, datatype:CLIPBRD_FORMAT):
+		self.data = data
+		self.datatype = datatype
+
+class RDP_CLIPBOARD_DATA_TXT(RDP_CLIPBOARD_DATA):
 	"""
 	This object will be dispatched on the external queue 
 	when the new clipboard data has arrived from the server to our client
 	"""
-	def __init__(self):
+	def __init__(self, data:str = '', datatype:CLIPBRD_FORMAT = CLIPBRD_FORMAT.CF_UNICODETEXT):
 		self.type = RDPDATATYPE.CLIPBOARD_DATA_TXT
-		self.data = None
-		self.datatype: CLIPBRD_FORMAT = None
+		self.data = data
+		self.datatype = datatype
 
 	def get_data(self, fmt:CLIPBRD_FORMAT = None):
 		if fmt is None:

--- a/aardwolf/connection.py
+++ b/aardwolf/connection.py
@@ -1155,15 +1155,18 @@ class RDPConnection:
 			return None, e
 	
 	async def get_current_clipboard_text(self):
-		if 'cliprdr' not in self.__joined_channels:
-			return None
-		return await self.__joined_channels['cliprdr'].get_current_clipboard_text()
+		if self.iosettings.clipboard is not None:
+			return await self.iosettings.clipboard.get_current_clipboard_text()
+		return None
 
 	async def set_current_clipboard_text(self, text:str):
-		if 'cliprdr' not in self.__joined_channels:
-			return None
-		return await self.__joined_channels['cliprdr'].set_current_clipboard_text(text)
+		if self.iosettings.clipboard is not None:
+			await self.iosettings.clipboard.set_current_clipboard_text(text)
 	
+	async def set_current_clipboard_files(self, filepaths):
+		if self.iosettings.clipboard is not None:
+			await self.iosettings.clipboard.set_current_clipboard_files(filepaths)
+
 	async def add_vchannel(self, channelname, handler):
 		if 'drdynvc' not in self.__joined_channels:
 			raise Exception('Dynamic Virtual Channels are not enabled on this connection!')

--- a/aardwolf/extensions/RDPECLIP/channel.py
+++ b/aardwolf/extensions/RDPECLIP/channel.py
@@ -8,7 +8,7 @@ from aardwolf import logger
 from aardwolf.channels import Channel
 from aardwolf.protocol.T124.userdata.constants import ChannelOption
 from aardwolf.extensions.RDPECLIP.protocol import *
-from aardwolf.extensions.RDPECLIP.protocol.clipboardcapabilities import CLIPRDR_GENERAL_CAPABILITY, CB_GENERAL_FALGS
+from aardwolf.extensions.RDPECLIP.protocol.clipboardcapabilities import CLIPRDR_GENERAL_CAPABILITY, CB_GENERAL_FLAGS
 from aardwolf.protocol.channelpdu import CHANNEL_PDU_HEADER, CHANNEL_FLAG
 from aardwolf.extensions.RDPECLIP.protocol.formatlist import CLIPBRD_FORMAT,CLIPRDR_SHORT_FORMAT_NAME, CLIPRDR_LONG_FORMAT_NAME
 from aardwolf.commons.queuedata import RDP_CLIPBOARD_NEW_DATA_AVAILABLE, RDP_CLIPBOARD_READY, RDPDATATYPE
@@ -32,7 +32,7 @@ class RDPECLIPChannel(Channel):
 		self.supported_formats = [CLIPBRD_FORMAT.CF_UNICODETEXT] #, CLIPBRD_FORMAT.CF_HDROP
 		self.server_caps = None
 		self.server_general_caps = None
-		self.client_general_caps_flags = CB_GENERAL_FALGS.HUGE_FILE_SUPPORT_ENABLED | CB_GENERAL_FALGS.FILECLIP_NO_FILE_PATHS | CB_GENERAL_FALGS.STREAM_FILECLIP_ENABLED #| CB_GENERAL_FALGS.USE_LONG_FORMAT_NAMES # CB_GENERAL_FALGS.CAN_LOCK_CLIPDATA | #| CB_GENERAL_FALGS.USE_LONG_FORMAT_NAMES
+		self.client_general_caps_flags = CB_GENERAL_FLAGS.HUGE_FILE_SUPPORT_ENABLED | CB_GENERAL_FLAGS.FILECLIP_NO_FILE_PATHS | CB_GENERAL_FLAGS.STREAM_FILECLIP_ENABLED #| CB_GENERAL_FLAGS.USE_LONG_FORMAT_NAMES # CB_GENERAL_FLAGS.CAN_LOCK_CLIPDATA | #| CB_GENERAL_FLAGS.USE_LONG_FORMAT_NAMES
 		self.current_server_formats = {}
 		self.__requested_format = None
 		self.__current_clipboard_data:RDP_CLIPBOARD_DATA_TXT = None

--- a/aardwolf/extensions/RDPECLIP/clipboard.py
+++ b/aardwolf/extensions/RDPECLIP/clipboard.py
@@ -1,5 +1,4 @@
-from dataclasses import dataclass
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import Dict, Iterable, Optional, List, Protocol
 
 from aardwolf.commons.queuedata.clipboard import RDP_CLIPBOARD_DATA, RDP_CLIPBOARD_DATA_FILELIST, RDP_CLIPBOARD_DATA_TXT
@@ -12,12 +11,6 @@ class ClipboardHandler(Protocol):
 		pass
 
 
-@dataclass
-class FileData:
-	path:PurePath # The full path to the file
-	file_descriptor:CLIPRDR_FILEDESCRIPTOR # The file descriptor
-
-
 class Clipboard:
 	def __init__(self, file_provider:FileProvider = None):
 		self._file_provider = FilesystemFileProvider() if file_provider is None else file_provider
@@ -26,7 +19,7 @@ class Clipboard:
 		self._next_format_id = 0xC000
 		self._handlers:List[ClipboardHandler] = []
 		self.file_copy_id = self.register_format('FileGroupDescriptorW')
-		self._file_data: List[FileData] = []
+		self._file_paths: List[PurePath] = []
 
 	@property
 	def formats(self) -> Dict[int, str]:
@@ -45,22 +38,22 @@ class Clipboard:
 		self._handlers.append(handler)
 
 	def get_file_size(self, index:int) -> int:
-		file_data = self._get_file_at_index(index)
-		if file_data is None:
+		file_path = self._get_file_at_index(index)
+		if file_path is None:
 			return 0
 
-		return self._file_provider.get_file_size(str(file_data.path))
+		return self._file_provider.get_file_size(str(file_path))
 
 	def get_file_data(self, index:int, start:int, count:int) -> bytes:
-		file_data = self._get_file_at_index(index)
-		if file_data is None:
+		file_path = self._get_file_at_index(index)
+		if file_path is None:
 			return b''
 
-		return self._file_provider.get_file_data(str(file_data.path), start, count)
+		return self._file_provider.get_file_data(str(file_path), start, count)
 
-	def _get_file_at_index(self, index:int) -> Optional[FileData]:
-		if index < len(self._file_data):
-			return self._file_data[index]
+	def _get_file_at_index(self, index:int) -> Optional[PurePath]:
+		if index < len(self._file_paths):
+			return self._file_paths[index]
 			
 		return None
 
@@ -72,15 +65,33 @@ class Clipboard:
 	async def set_current_clipboard_files(self, files:Iterable[PurePath]):
 		file_list = CLIPRDR_FILELIST()
 		for f in files:
-			file = CLIPRDR_FILEDESCRIPTOR()
-			file.flags = FD_FLAGS.ATTRIBUTES
-			file.fileAttributes = FILE_ATTRIBUTE.NORMAL # Note: not handling directories
-			file.fileName = f.parts[-1]
-			self._file_data.append(FileData(path=f, file_descriptor=file))
-			file_list.fileDescriptorArray.append(file)
+			self._file_paths.append(f)
+
+			path = Path(f)
+			file_descriptor = self._create_filedescriptor(path)
+			file_list.fileDescriptorArray.append(file_descriptor)
+			self._recurse_path(path, file_list.fileDescriptorArray)
 
 		data = RDP_CLIPBOARD_DATA_FILELIST(data=file_list, datatype=self.file_copy_id)
 		await self.set_data(data)
+
+	def _create_filedescriptor(self, path:Path, depth:int = 0) -> CLIPRDR_FILEDESCRIPTOR:
+		file = CLIPRDR_FILEDESCRIPTOR()
+		file.flags = FD_FLAGS.ATTRIBUTES
+		attributes = FILE_ATTRIBUTE.DIRECTORY if path.is_dir() else FILE_ATTRIBUTE.NORMAL
+		file.fileAttributes = attributes
+		file.fileName = str(Path(*path.parts[-(1 + depth):]))
+		return file
+
+	def _recurse_path(self, path:Path, file_descriptors:List[CLIPRDR_FILEDESCRIPTOR], depth:int = 0):
+		if not path.is_dir():
+			return
+		
+		for p in path.iterdir():
+			self._file_paths.append(p)
+			file_descriptor = self._create_filedescriptor(p, depth + 1)
+			file_descriptors.append(file_descriptor)
+			self._recurse_path(p, file_descriptors, depth + 1)
 
 	async def get_current_clipboard_text(self) -> str:
 		if self.data is None or self.data.datatype not in [CLIPBRD_FORMAT.CF_UNICODETEXT]:
@@ -96,7 +107,7 @@ class Clipboard:
 			return
 
 		if data.datatype != self.file_copy_id:
-			self._file_data = []
+			self._file_paths = []
 
 		self.data = data
 		await self.notify_copy(data)

--- a/aardwolf/extensions/RDPECLIP/clipboard.py
+++ b/aardwolf/extensions/RDPECLIP/clipboard.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+from pathlib import PurePath
+from typing import Dict, Iterable, Optional, List, Protocol
+
+from aardwolf.commons.queuedata.clipboard import RDP_CLIPBOARD_DATA, RDP_CLIPBOARD_DATA_FILELIST, RDP_CLIPBOARD_DATA_TXT
+from aardwolf.extensions.RDPECLIP.fileprovider import FileProvider, FilesystemFileProvider
+from aardwolf.extensions.RDPECLIP.protocol.formatlist import CLIPBRD_FORMAT
+from aardwolf.extensions.RDPECLIP.protocol.formatdataresponse import CLIPRDR_FILELIST, CLIPRDR_FILEDESCRIPTOR, FILE_ATTRIBUTE, FD_FLAGS
+
+class ClipboardHandler(Protocol):
+	async def on_copy(self, data:RDP_CLIPBOARD_DATA):
+		pass
+
+
+@dataclass
+class FileData:
+	path:PurePath # The full path to the file
+	file_descriptor:CLIPRDR_FILEDESCRIPTOR # The file descriptor
+
+
+class Clipboard:
+	def __init__(self, file_provider:FileProvider = None):
+		self._file_provider = FilesystemFileProvider() if file_provider is None else file_provider
+		self._formats:Dict[int, str] = {f.value : '' for f in CLIPBRD_FORMAT if f != CLIPBRD_FORMAT.UNKNOWN}
+		self.data:Optional[RDP_CLIPBOARD_DATA] = None
+		self._next_format_id = 0xC000
+		self._handlers:List[ClipboardHandler] = []
+		self.file_copy_id = self.register_format('FileGroupDescriptorW')
+		self._file_data: List[FileData] = []
+
+	@property
+	def formats(self) -> Dict[int, str]:
+		return self._formats
+
+	def register_format(self, format_name:str) -> int:
+		for k, v in self._formats.items():
+			if v == format_name:
+				return k
+
+		format_id = self._get_format_id()
+		self._formats[format_id] = format_name
+		return format_id
+
+	def register_handler(self, handler:ClipboardHandler):
+		self._handlers.append(handler)
+
+	def get_file_size(self, index:int) -> int:
+		file_data = self._get_file_at_index(index)
+		if file_data is None:
+			return 0
+
+		return self._file_provider.get_file_size(str(file_data.path))
+
+	def get_file_data(self, index:int, start:int, count:int) -> bytes:
+		file_data = self._get_file_at_index(index)
+		if file_data is None:
+			return b''
+
+		return self._file_provider.get_file_data(str(file_data.path), start, count)
+
+	def _get_file_at_index(self, index:int) -> Optional[FileData]:
+		if index < len(self._file_data):
+			return self._file_data[index]
+			
+		return None
+
+	def _get_format_id(self) -> int:
+		format_id = self._next_format_id
+		self._next_format_id += 1
+		return format_id
+	
+	async def set_current_clipboard_files(self, files:Iterable[PurePath]):
+		file_list = CLIPRDR_FILELIST()
+		for f in files:
+			file = CLIPRDR_FILEDESCRIPTOR()
+			file.flags = FD_FLAGS.ATTRIBUTES
+			file.fileAttributes = FILE_ATTRIBUTE.NORMAL # Note: not handling directories
+			file.fileName = f.parts[-1]
+			self._file_data.append(FileData(path=f, file_descriptor=file))
+			file_list.fileDescriptorArray.append(file)
+
+		data = RDP_CLIPBOARD_DATA_FILELIST(data=file_list, datatype=self.file_copy_id)
+		await self.set_data(data)
+
+	async def get_current_clipboard_text(self) -> str:
+		if self.data is None or self.data.datatype not in [CLIPBRD_FORMAT.CF_UNICODETEXT]:
+			return ''
+		return str(self.data.data)
+
+	async def set_current_clipboard_text(self, text:str):
+		data = RDP_CLIPBOARD_DATA_TXT(data=text, datatype=CLIPBRD_FORMAT.CF_UNICODETEXT)
+		await self.set_data(data)
+				
+	async def set_data(self, data:RDP_CLIPBOARD_DATA, force_refresh = True):
+		if data == self.data and force_refresh is False:
+			return
+
+		if data.datatype != self.file_copy_id:
+			self._file_data = []
+
+		self.data = data
+		await self.notify_copy(data)
+
+	async def notify_copy(self, data:RDP_CLIPBOARD_DATA):
+		# Inform the channel of a copy
+		for handler in self._handlers:
+			await handler.on_copy(data)

--- a/aardwolf/extensions/RDPECLIP/fileprovider.py
+++ b/aardwolf/extensions/RDPECLIP/fileprovider.py
@@ -1,0 +1,50 @@
+from abc import ABC, abstractmethod
+from os import lstat
+from typing import Dict
+
+
+class FileProvider(ABC):
+	"""
+	File access for the clipboard
+	"""
+
+	@abstractmethod
+	def get_file_data(self, name:str, start:int, count:int) -> bytes:
+		"""
+		Read data from the file with the given name
+		
+		Args:
+			name: Name of the file from which to read
+			start: Offset from the beginning of the file, in bytes
+			count: Maximum number of bytes to read
+		Returns:
+			The file data
+		"""
+		pass
+
+	@abstractmethod
+	def get_file_size(self, name:str) -> int:
+		"""
+		Get the size of the file with the given name
+
+		Args:
+			name: Name of the file
+		Returns:
+			The file size, in bytes
+		"""
+		pass
+
+
+class FilesystemFileProvider(FileProvider):
+	"""
+	Provides file data to the clipboard
+	"""
+
+	def get_file_data(self, name:str, start:int, count:int) -> bytes:
+		with open(name, 'rb') as f:
+			f.seek(start)
+			return f.read(count)
+		
+	def get_file_size(self, name:str) -> int:
+		stat = lstat(name)
+		return stat.st_size

--- a/aardwolf/extensions/RDPECLIP/protocol/clipboardcapabilities.py
+++ b/aardwolf/extensions/RDPECLIP/protocol/clipboardcapabilities.py
@@ -9,7 +9,7 @@ class CB_CAPS_VERSION(enum.Enum):
 	VERSION_1 = 0x00000001 #Version 1
 	VERSION_2 = 0x00000002 #Version 2
 
-class CB_GENERAL_FALGS(enum.IntFlag):
+class CB_GENERAL_FLAGS(enum.IntFlag):
 	USE_LONG_FORMAT_NAMES = 0x00000002 #The Long Format Name variant of the Format List PDU is supported for exchanging updated format names. If this flag is not set, the Short Format Name variant MUST be used. If this flag is set by both protocol endpoints, then the Long Format Name variant MUST be used.
 	STREAM_FILECLIP_ENABLED = 0x00000004 #File copy and paste using stream-based operations are supported using the File Contents Request PDU and File Contents Response PDU.
 	FILECLIP_NO_FILE_PATHS = 0x00000008 #Indicates that any description of files to copy and paste MUST NOT include the source path of the files.
@@ -21,7 +21,7 @@ class CLIPRDR_GENERAL_CAPABILITY:
 		self.capabilitySetType:CAPSTYPE = CAPSTYPE.GENERAL
 		self.lengthCapability:int = 12
 		self.version:CB_CAPS_VERSION = CB_CAPS_VERSION.VERSION_2
-		self.generalFlags:CB_GENERAL_FALGS = 0
+		self.generalFlags:CB_GENERAL_FLAGS = 0
 
 	def to_bytes(self):
 		t = self.capabilitySetType.value.to_bytes(2, byteorder='little', signed = False)
@@ -40,7 +40,7 @@ class CLIPRDR_GENERAL_CAPABILITY:
 		msg.capabilitySetType = CAPSTYPE(int.from_bytes(buff.read(2), byteorder='little', signed = False))
 		msg.lengthCapability = int.from_bytes(buff.read(2), byteorder='little', signed = False)
 		msg.version = CB_CAPS_VERSION(int.from_bytes(buff.read(4), byteorder='little', signed = False))
-		msg.generalFlags = CB_GENERAL_FALGS(int.from_bytes(buff.read(4), byteorder='little', signed = False))
+		msg.generalFlags = CB_GENERAL_FLAGS(int.from_bytes(buff.read(4), byteorder='little', signed = False))
 		return msg
 
 	def __repr__(self):

--- a/aardwolf/extensions/RDPECLIP/protocol/clipboardcapabilities.py
+++ b/aardwolf/extensions/RDPECLIP/protocol/clipboardcapabilities.py
@@ -47,7 +47,7 @@ class CLIPRDR_GENERAL_CAPABILITY:
 		t = '==== CLIPRDR_GENERAL_CAPABILITY ====\r\n'
 		for k in self.__dict__:
 			if isinstance(self.__dict__[k], enum.IntFlag):
-				value = self.__dict__[k]
+				value = repr(self.__dict__[k])
 			elif isinstance(self.__dict__[k], enum.Enum):
 				value = self.__dict__[k].name
 			else:

--- a/aardwolf/extensions/RDPECLIP/protocol/filecontentsresponse.py
+++ b/aardwolf/extensions/RDPECLIP/protocol/filecontentsresponse.py
@@ -10,7 +10,10 @@ class CLIPRDR_FILECONTENTS_RESPONSE:
 
 	def to_bytes(self):
 		t = self.streamId.to_bytes(4, byteorder='little', signed = False)
-		t += self.requestedFileContentsData
+		if isinstance(self.requestedFileContentsData, int):
+			t += self.requestedFileContentsData.to_bytes(8, byteorder='little', signed = False)
+		else:
+			t += self.requestedFileContentsData
 		return t
 
 	@staticmethod

--- a/aardwolf/extensions/RDPECLIP/protocol/formatdataresponse.py
+++ b/aardwolf/extensions/RDPECLIP/protocol/formatdataresponse.py
@@ -148,13 +148,13 @@ class CLIPRDR_FILEDESCRIPTOR:
 		self.flags:FD_FLAGS = None
 		self.reserved1:bytes = b'\x00'*32
 		self.fileAttributes:FILE_ATTRIBUTE = None
-		self.reserved2:bytes = None
-		self.lastWriteTime:int = None
-		self.fileSizeHigh:int = None
-		self.fileSizeLow:int = None
+		self.reserved2:bytes = b'\x00'*16
+		self.lastWriteTime:int = 0
+		self.fileSizeHigh:int = 0
+		self.fileSizeLow:int = 0
 		self.fileName:str = None #520 bytes, 260 chars null term
 
-		self.fileSize:int =None
+		self.fileSize:int =0
 
 	def to_bytes(self):
 		if self.fileSize is not None:
@@ -168,7 +168,7 @@ class CLIPRDR_FILEDESCRIPTOR:
 		t += self.lastWriteTime.to_bytes(8, byteorder='little', signed=False)
 		t += self.fileSizeHigh.to_bytes(4, byteorder='little', signed=False)
 		t += self.fileSizeLow.to_bytes(4, byteorder='little', signed=False)
-		t += self.fileName.encode('utf-16-le').ljust(b'\x00',520)
+		t += self.fileName.encode('utf-16-le').ljust(520, b'\x00')
 		return t
 
 	@staticmethod
@@ -204,7 +204,7 @@ class CLIPRDR_FILEDESCRIPTOR:
 
 class CLIPRDR_FILELIST:
 	def __init__(self):
-		self.cItems:MAPPING_MODE = None
+		self.cItems:int = None
 		self.fileDescriptorArray:List[CLIPRDR_FILEDESCRIPTOR] = []
 
 	def to_bytes(self):


### PR DESCRIPTION
Adds the ability to copy a set of files from the client to server over RDP. Only client->server has been implemented

Also note that I've used Protocols here, which is a feature of Python 3.8 (Python 3.7 is EOL).