### PR TITLE
added option to negotiate obsolete SSL ciphers (old windows server)

### DIFF
--- a/aardwolf/commons/target.py
+++ b/aardwolf/commons/target.py
@@ -38,10 +38,12 @@ class RDPTarget(UniTarget):
 			domain:str = None, 
 			proxies:List[UniProxyTarget] = None, 
 			protocol:UniProto = UniProto.CLIENT_TCP, 
+			unsafe_ssl:bool = False,
 			dialect:RDPConnectionDialect = RDPConnectionDialect.RDP,
 			dns:str = None):
 		UniTarget.__init__(self, ip, port, protocol, timeout, hostname = hostname, proxies = proxies, domain = domain, dc_ip = dc_ip, dns=dns)
 		self.dialect = dialect
+		self.unsafe_ssl = unsafe_ssl
 		if self.dialect == RDPConnectionDialect.VNC:
 			self.port = 5900
 
@@ -58,6 +60,7 @@ class RDPTarget(UniTarget):
 			domain = self.domain, 
 			proxy = copy.deepcopy(self.proxy),
 			protocol = self.protocol,
+			unsafe_ssl = self.unsafe_ssl,
 			dialect = self.dialect,
 			dns=self.dns
 		)

--- a/aardwolf/connection.py
+++ b/aardwolf/connection.py
@@ -1,5 +1,6 @@
 
 import io
+import ssl
 import copy
 import typing
 import asyncio
@@ -269,7 +270,12 @@ class RDPConnection:
 				self.x224_flag = self.x224_connection_reply.flags
 				logger.debug('Server selected protocol: %s' % self.x224_protocol)
 				if SUPP_PROTOCOLS.SSL in self.x224_protocol or SUPP_PROTOCOLS.HYBRID in self.x224_protocol or SUPP_PROTOCOLS.HYBRID_EX in self.x224_protocol:
-					await self.__connection.wrap_ssl()
+					ssl_ctx = ssl.create_default_context()
+					ssl_ctx.check_hostname = False
+					ssl_ctx.verify_mode = ssl.CERT_NONE
+					if self.target.unsafe_ssl: ssl_ctx.set_ciphers('ALL:@SECLEVEL=0')
+					
+					await self.__connection.wrap_ssl(ssl_ctx=ssl_ctx)
 
 				# if the server expects HYBRID/HYBRID_EX authentication we do that here
 				# This is basically credSSP

--- a/aardwolf/connection.py
+++ b/aardwolf/connection.py
@@ -270,12 +270,14 @@ class RDPConnection:
 				self.x224_flag = self.x224_connection_reply.flags
 				logger.debug('Server selected protocol: %s' % self.x224_protocol)
 				if SUPP_PROTOCOLS.SSL in self.x224_protocol or SUPP_PROTOCOLS.HYBRID in self.x224_protocol or SUPP_PROTOCOLS.HYBRID_EX in self.x224_protocol:
-					ssl_ctx = ssl.create_default_context()
-					ssl_ctx.check_hostname = False
-					ssl_ctx.verify_mode = ssl.CERT_NONE
-					if self.target.unsafe_ssl: ssl_ctx.set_ciphers('ALL:@SECLEVEL=0')
-					
-					await self.__connection.wrap_ssl(ssl_ctx=ssl_ctx)
+					if self.target.unsafe_ssl:
+						ssl_ctx = ssl.create_default_context()
+						ssl_ctx.check_hostname = False
+						ssl_ctx.verify_mode = ssl.CERT_NONE
+						ssl_ctx.set_ciphers('ALL:@SECLEVEL=0')
+						await self.__connection.wrap_ssl(ssl_ctx=ssl_ctx)
+					else:
+						await self.__connection.wrap_ssl()
 
 				# if the server expects HYBRID/HYBRID_EX authentication we do that here
 				# This is basically credSSP


### PR DESCRIPTION
On some old windows servers, the default client [SSL Security Level](https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/) is set too high (2) to allow the SSL negociation and establish an RDP connection.
The `unsafe_ssl` option added to the `RDPTarget` allows to lower this level to 0 aka. "Everything is permitted." .

I'm not sure if I added this in the right place, if not, feel free to tell me where it'd be more appropriate :)

Thanks 